### PR TITLE
Use 1.14 release of verapdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - gem update --system
 install:
   - bundle install --without development
-  - wget http://software.verapdf.org/releases/1.12/verapdf-greenfield-1.12.1-installer.zip -O /tmp/verapdf-installer.zip
+  - wget http://software.verapdf.org/releases/1.14/verapdf-greenfield-1.14.2-installer.zip -O /tmp/verapdf-installer.zip
   - unzip /tmp/verapdf-installer.zip -d /tmp/verapdf-installer
   - java -jar /tmp/verapdf-installer/*/verapdf-izpack-installer-*.jar verapdf-auto-install.xml
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && \
 
 # Install verapdf
 ADD verapdf-auto-install.xml /tmp/verapdf-auto-install.xml
-RUN wget http://software.verapdf.org/releases/1.12/verapdf-greenfield-1.12.1-installer.zip -O /tmp/verapdf-installer.zip
+RUN wget http://software.verapdf.org/releases/1.14/verapdf-greenfield-1.14.2-installer.zip -O /tmp/verapdf-installer.zip
 RUN unzip /tmp/verapdf-installer.zip -d /tmp/verapdf-installer
 RUN java -jar /tmp/verapdf-installer/*/verapdf-izpack-installer-*.jar /tmp/verapdf-auto-install.xml
 RUN rm -rf /tmp/verapdf*


### PR DESCRIPTION
Docker image for `ruby:2.6` update and includes `java 11`
And verapdf 1.12 cause error while working with this java
See:
https://github.com/veraPDF/veraPDF-apps/pull/254