### PR TITLE
Fix installing verapdf dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Verapd
       run: |
-		 sudo apt -y update
+        sudo apt -y update
         sudo apt-get -y install default-jre unzip wget
         wget http://software.verapdf.org/releases/1.14/verapdf-greenfield-1.14.8-installer.zip -O /tmp/verapdf-installer.zip
         unzip /tmp/verapdf-installer.zip -d /tmp/verapdf-installer

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Verapd
       run: |
+		 sudo apt -y update
         sudo apt-get -y install default-jre unzip wget
         wget http://software.verapdf.org/releases/1.14/verapdf-greenfield-1.14.8-installer.zip -O /tmp/verapdf-installer.zip
         unzip /tmp/verapdf-installer.zip -d /tmp/verapdf-installer


### PR DESCRIPTION
Without update it fail with
```
Err:2 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 openjdk-11-jre-headless amd64 11.0.7+10-2ubuntu2~18.04
  404  Not Found [IP: 52.177.174.250 80]
```